### PR TITLE
Add Beacon and Multi-Event capabilities

### DIFF
--- a/templates/ethiack-job-manager.yaml
+++ b/templates/ethiack-job-manager.yaml
@@ -24,6 +24,14 @@ spec:
             type: string
             default: ""
             description: The URL of the target service. Required for commands "launch", and "check".
+        beacon_id:
+            type: string
+            default: ""
+            description: Optional beacon_id for "launch" and "check" commands.
+        event_slug:
+            type: string
+            default: ""
+            description: Optional event_slug for "launch" and "check" commands.
         args:
             type: string
             default: ""
@@ -51,6 +59,16 @@ ethiack-job-manager:
           if [ "$[[ inputs.command ]]" = "launch" ] || [ "$[[ inputs.command ]]" = "check" ]; then
               if [ -n "$[[ inputs.url ]]" ]; then
                   COMMAND="$COMMAND $[[ inputs.url ]]"
+                  
+                  # Add optional beacon_id if provided
+                  if [ -n "$[[ inputs.beacon_id ]]" ]; then
+                      COMMAND="$COMMAND --beacon-id $[[ inputs.beacon_id ]]"
+                  fi
+                  
+                  # Add optional event_slug if provided
+                  if [ -n "$[[ inputs.event_slug ]]" ]; then
+                      COMMAND="$COMMAND --event-slug $[[ inputs.event_slug ]]"
+                  fi
               else
                   echo "Error: URL is required for the $[[ inputs.command ]] command."
                   exit 1


### PR DESCRIPTION
This pull request includes updates to the `templates/ethiack-job-manager.yaml` file to add support for optional parameters `beacon_id` and `event_slug` in the "launch" and "check" commands.

Enhancements:

* [`templates/ethiack-job-manager.yaml`](diffhunk://#diff-e1e8feec6b11acf84e87be13dd5c5d4253f0fcd484d1bad68f02f61b156cd04dR27-R34): Added `beacon_id` and `event_slug` as optional parameters in the `spec` section.
* [`templates/ethiack-job-manager.yaml`](diffhunk://#diff-e1e8feec6b11acf84e87be13dd5c5d4253f0fcd484d1bad68f02f61b156cd04dR62-R71): Updated the command execution logic to include `beacon_id` and `event_slug` if they are provided.