### PR TITLE
ci: update commitlint config

### DIFF
--- a/.github/configs/commitlint.config.js
+++ b/.github/configs/commitlint.config.js
@@ -1,27 +1,9 @@
-const { maxLineLength } = require('@commitlint/ensure')
-
-const bodyMaxLineLength = 100
-
-const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
-  const { type, scope, body } = parsedCommit
-  const isDepsCommit =
-    type === 'chore' && scope === 'release'
-
-  return [
-    isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),
-    `body's lines must not be longer than ${bodyMaxLineLength}`,
-  ]
-}
-
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  plugins: ['commitlint-plugin-function-rules'],
   rules: {
-    'body-max-line-length': [0],
-    'function-rules/body-max-line-length': [
-      2,
-      'always',
-      validateBodyMaxLengthIgnoringDeps,
-    ],
+	'body-max-line-length': [1, 'always', 100], // warning
+	'header-max-length': [1, 'always', 100], // warning
+	'footer-max-line-length': [1, 'always', 100], // warning
+	'subject-case': [1, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']], // warning
   },
 }


### PR DESCRIPTION
This pull request includes changes to the commit linting configuration to simplify and standardize commit message rules. The most important changes involve removing custom validation functions and replacing them with standard rules.

Commit linting configuration changes:

* Removed custom validation function `validateBodyMaxLengthIgnoringDeps` and associated plugin `commitlint-plugin-function-rules`.
* Added standard rules for `body-max-line-length`, `header-max-length`, `footer-max-line-length`, and `subject-case` with warning levels.