### PR TITLE
docs: updating company legal name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ethiack, Lda.
+Copyright (c) 2025 Ethiack, S.A.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright information in the `LICENSE` file to reflect the correct year and company name.

* Changed the copyright year from 2024 to 2025 and updated the company name from "Ethiack, Lda." to "Ethiack, S.A." in `LICENSE`.